### PR TITLE
Define BORDER_INTERP_DEFAULT

### DIFF
--- a/ncorr_app/core/__init__.py
+++ b/ncorr_app/core/__init__.py
@@ -4,11 +4,16 @@ Public re-exports for the *core* layer of the Ncorr Python port.
 
 from .image import NcorrImage
 from .roi import NcorrROI
-from .datatypes import OutputState, RegionData
+from .datatypes import (
+    BORDER_INTERP_DEFAULT,
+    OutputState,
+    RegionData,
+)
 
 __all__ = [
     "NcorrImage",
     "NcorrROI",
     "OutputState",
     "RegionData",
+    "BORDER_INTERP_DEFAULT",
 ]

--- a/ncorr_app/core/datatypes.py
+++ b/ncorr_app/core/datatypes.py
@@ -11,7 +11,11 @@ from typing import List
 __all__ = [
     "OutputState",
     "RegionData",
+    "BORDER_INTERP_DEFAULT",
 ]
+
+# Default padding used when interpolating along ROI boundaries.
+BORDER_INTERP_DEFAULT = 20
 
 
 class OutputState(enum.IntEnum):


### PR DESCRIPTION
## Summary
- define `BORDER_INTERP_DEFAULT` constant in `datatypes`
- re-export constant through `core.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d571903483339c9c0ce3884a7432